### PR TITLE
docs(common): excluding npm useless files from pushing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 
 .DS_STORE
+
+# Excluding node_modules
+
+node_modules
+package-lock.json


### PR DESCRIPTION
Excluding node_modules from pushing into GitHub repo